### PR TITLE
PROJ-123: Add Address property to Person object

### DIFF
--- a/WebApiSample/WebApiSample/Controllers/PersonsController.cs
+++ b/WebApiSample/WebApiSample/Controllers/PersonsController.cs
@@ -77,6 +77,7 @@ namespace WebApiSample.Controllers
                 }
 
                 value.Name = newValue.Name;
+                value.Address = newValue.Address;
 
                 db.SaveChanges();
             }

--- a/WebApiSample/WebApiSample/Models/Person.cs
+++ b/WebApiSample/WebApiSample/Models/Person.cs
@@ -11,5 +11,6 @@ namespace WebApiSample.Models
         [Key]
         public string Phone { get; set; }
         public string Name { get; set; }
+        public string Address { get; set; }
     }
 }


### PR DESCRIPTION
This pull request adds an `Address` property to the `Person` model in the Web API. This allows storage and retrieval of a person's address via the API.

- What was changed: Added `Address` property to the `Person` model.
- Why it was changed: As per PROJ-123, the API needs to store and expose address information for a person.
- Potential impacts: This change modifies the `Person` model, which will affect all API endpoints that handle `Person` objects. Clients consuming the API will need to be updated to handle the new `Address` property.  A database migration will be required.
- Testing instructions: After applying the migration, create, read, update, and delete person objects via the API to ensure the Address field is correctly persisted and retrieved. Verify that the API continues to function as expected with existing clients that may not yet be updated to use the Address field (ensure that the API doesn't break if the Address field is null/empty).

No tests were added because the existing project lacks any unit or integration tests.  Adding address validation or more robust testing is beyond the scope of this ticket.  Future tickets should address the lack of comprehensive testing.