### PR TITLE
PROJ-123: Add Address property to Person object in API

### DIFF
--- a/WebApiSample/WebApiSample/Controllers/PersonsController.cs
+++ b/WebApiSample/WebApiSample/Controllers/PersonsController.cs
@@ -77,6 +77,7 @@ namespace WebApiSample.Controllers
                 }
 
                 value.Name = newValue.Name;
+                value.Address = newValue.Address;
 
                 db.SaveChanges();
             }

--- a/WebApiSample/WebApiSample/Models/Person.cs
+++ b/WebApiSample/WebApiSample/Models/Person.cs
@@ -11,5 +11,6 @@ namespace WebApiSample.Models
         [Key]
         public string Phone { get; set; }
         public string Name { get; set; }
+        public string Address { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds an `Address` property to the `Person` model, allowing storage and retrieval of a person's address through the API.

- **What:** Added an `Address` property (string) to the `Person` model.
- **Why:** The application needs to store address information for people.
- **Potential Impacts:** This change modifies the `Person` model and database schema. All API interactions involving the `Person` object will now include the `Address` property.  This may require updates to client applications.
- **Testing Instructions:**
  1. Apply the patch.
  2. Update the database with `Update-Database` in the Package Manager Console.
  3. Test POST, PUT, and GET operations on the `/api/persons` endpoint to ensure the `Address` property is correctly handled.  Verify that a person can be created with an address, an existing person's address can be updated, and the address is included in GET requests.
  4.  Ensure that all existing functionality related to the API continues to operate as expected.