### PR TITLE
PROJ-123: Add Address property to Person model

### DIFF
--- a/WebApiSample/WebApiSample/Controllers/PersonsController.cs
+++ b/WebApiSample/WebApiSample/Controllers/PersonsController.cs
@@ -77,6 +77,7 @@ namespace WebApiSample.Controllers
                 }
 
                 value.Name = newValue.Name;
+                value.Address = newValue.Address;
 
                 db.SaveChanges();
             }

--- a/WebApiSample/WebApiSample/Models/Person.cs
+++ b/WebApiSample/WebApiSample/Models/Person.cs
@@ -11,5 +11,6 @@ namespace WebApiSample.Models
         [Key]
         public string Phone { get; set; }
         public string Name { get; set; }
+        public string Address { get; set; }
     }
 }


### PR DESCRIPTION
This pull request addresses PROJ-123, adding an `Address` property to the `Person` model.

- **What:** Added a new `Address` property of type `string` to the `Person` model.
- **Why:** The API needs to store the address of a person.
- **Potential Impacts:** Requires database schema update if using a database.  API consumers will need to be aware of the new property.
- **Testing Instructions:**
  1.  Apply the patch.
  2.  Run all unit tests to ensure they pass.
  3.  Test the API endpoints to verify that the `Address` property can be set and retrieved.
